### PR TITLE
#11 - Remove Tailwind and related dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@angular/platform-browser": "^20.0.5",
         "@angular/platform-browser-dynamic": "^20.0.5",
         "@angular/router": "^20.0.5",
-        "@ngneat/tailwind": "^7.0.3",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.1"
@@ -33,8 +32,6 @@
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
-        "postcss": "^8.5.6",
-        "tailwindcss": "^4.1.11",
         "typescript": "~5.8.3"
       }
     },
@@ -2788,12 +2785,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/@ngneat/tailwind": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@ngneat/tailwind/-/tailwind-7.0.3.tgz",
-      "integrity": "sha512-o9quceIAomYD+P/40tJ1n1G/CkWcAa1dWW5/acCz4qnS7ajhGsBoSD4N+usi+vqdoEJnunCsoEBWL9OMsSwcFA==",
-      "license": "MIT"
     },
     "node_modules/@npmcli/agent": {
       "version": "3.0.0",
@@ -9006,7 +8997,9 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tar": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@angular/platform-browser": "^20.0.5",
     "@angular/platform-browser-dynamic": "^20.0.5",
     "@angular/router": "^20.0.5",
-    "@ngneat/tailwind": "^7.0.3",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.1"
@@ -35,8 +34,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
-    "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.11",
     "typescript": "~5.8.3"
   }
 }


### PR DESCRIPTION
Deleted @ngneat/tailwind, tailwindcss, and postcss from dependencies in package.json and package-lock.json. This cleans up unused or unneeded styling dependencies from the project.