### PR TITLE
#17 - Refactor calendar event property names and types

### DIFF
--- a/src/components/calendar/mes/mes.html
+++ b/src/components/calendar/mes/mes.html
@@ -27,7 +27,7 @@
         <div
           *ngFor="let evento of obterEventosDoDia(dia) | slice : 0 : 3"
           class="evento-calendario"
-          [ngStyle]="obterEstiloDoEvento(evento.cor)"
+          [ngStyle]="obterEstiloDoEvento(evento.color)"
           (click)="
             acoesEvento?.length
               ? abrirMenu($event, evento)
@@ -35,10 +35,10 @@
           "
         >
           <div class="texto-limitado">
-            <strong>{{ evento.titulo }}</strong>
+            <strong>{{ evento.title }}</strong>
           </div>
           <div>
-            <small>{{ evento.horaInicio }} - {{ evento.horaFim }}</small>
+            <small>{{ evento.startTime }} - {{ evento.endTime }}</small>
           </div>
         </div>
 
@@ -58,7 +58,7 @@
           <div
             *ngFor="let evento of obterEventosDoDia(dia)"
             class="evento-popover"
-            [ngStyle]="obterEstiloDoEvento(evento.cor)"
+            [ngStyle]="obterEstiloDoEvento(evento.color)"
             (click)="
               acoesEvento?.length
                 ? abrirMenu($event, evento)
@@ -66,10 +66,10 @@
             "
           >
             <div>
-              <strong>{{ evento.titulo }}</strong>
+              <strong>{{ evento.title }}</strong>
             </div>
             <div>
-              <small>{{ evento.horaInicio }} - {{ evento.horaFim }}</small>
+              <small>{{ evento.startTime }} - {{ evento.endTime }}</small>
             </div>
           </div>
           <button class="btn btn-primary" (click)="fecharPopover($event)">

--- a/src/components/calendar/mes/mes.ts
+++ b/src/components/calendar/mes/mes.ts
@@ -13,7 +13,7 @@ import {
   Output,
   SimpleChanges,
 } from '@angular/core';
-import { ICalendarioEvento } from '../interfaces';
+import { ICalendarEvent } from '../interfaces';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -27,14 +27,14 @@ import { FormsModule } from '@angular/forms';
 export class VisualizacaoMensalComponent
   implements OnInit, OnChanges, OnDestroy
 {
-  @Input() eventos: Array<ICalendarioEvento> = [];
+  @Input() eventos: Array<ICalendarEvent> = [];
   @Input() desabilitarAdicionarEvento = false;
   @Input() desabilitarIrParaProximoMes = false;
   @Input() desabilitarIrParaMesAnterior = false;
   @Input() dataInicial?: string;
   @Input() periodoMarcadoParaEventos?: { dataInicial: string; dataFim: string };
   @Output() cliqueAdicionarEvento = new EventEmitter<{ data: Date }>();
-  @Output() cliqueVisualizarEvento = new EventEmitter<ICalendarioEvento>();
+  @Output() cliqueVisualizarEvento = new EventEmitter<ICalendarEvent>();
   @Output() mesMudou = new EventEmitter<{ mes: string; ano: number }>();
   @Input() acoesEvento: { nome: string; metodo: (evento: any) => void }[] = [];
   menuVisivel = false;
@@ -192,9 +192,9 @@ export class VisualizacaoMensalComponent
     this.cliqueAdicionarEvento.emit({ data });
   }
 
-  obterEventosDoDia(dia: string): ICalendarioEvento[] {
+  obterEventosDoDia(dia: string): ICalendarEvent[] {
     return this.eventos.filter(
-      (evento) => this.normalizarData(evento.data) === this.normalizarData(dia)
+      (evento) => this.normalizarData(evento.date) === this.normalizarData(dia)
     );
   }
 

--- a/src/components/calendar/semana/week.html
+++ b/src/components/calendar/semana/week.html
@@ -81,7 +81,7 @@
       class="px-3 py-2 text-sm text-gray-700 dark:text-gray-200 cursor-pointer
              hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors duration-150"
       *ngFor="let action of actions"
-      (click)="actionMethod(action.method)">
+      (click)="executeAction(action.method)">
       {{ action.name }}
     </div>
   </div>

--- a/src/components/calendar/semana/week.ts
+++ b/src/components/calendar/semana/week.ts
@@ -25,12 +25,15 @@ export class WeekViewComponent implements OnInit, OnChanges {
     end: 23,
     interval: 60,
   };
+  @Input() actions: { name: string; method: (event: any) => void }[] = [];
   @Output() clickAddEvent = new EventEmitter<{
     date: Date;
     startTime: string;
   }>();
   @Output() clickViewEvent = new EventEmitter<any>();
   @Output() monthChanged = new EventEmitter<{ month: string; year: number }>();
+
+
 
   daysOfWeek: { date: Date; events: ICalendarEvent[] }[] = [];
   markedDays: string[] = [];


### PR DESCRIPTION
Updated event property names in month and week calendar components to use English terms (e.g., 'title', 'color', 'startTime', 'endTime', 'date') and switched to the ICalendarEvent interface. Also added 'actions' input to week view and renamed method for executing actions. This improves consistency and prepares for internationalization.