### PR TITLE
#30 - Add toast notification component and update event modal

### DIFF
--- a/src/components/calendar/calendario.component.html
+++ b/src/components/calendar/calendario.component.html
@@ -99,7 +99,7 @@
   </div>
 
   <!-- Modal de detalhes do evento -->
-  <div
+  <!-- <div
     *ngIf="showEventModal"
     class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
     (click)="closeEventModal()"
@@ -147,7 +147,7 @@
         </button>
       </div>
     </div>
-  </div>
+  </div> -->
 
   <!-- Toast de notificação -->
   <div

--- a/src/components/event-modal/event-modal.ts
+++ b/src/components/event-modal/event-modal.ts
@@ -2,12 +2,12 @@ import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 export interface ModalData {
-  title?: string;
-  date?: Date | string;
-  startTime?: string;
-  endTime?: string;
-  description?: string;
-  color?: string;
+  title?: string | null;
+  date?: Date | string | null;
+  startTime?: string | null;
+  endTime?: string | null;
+  description?: string | null;
+  color?: string | null;
 }
 
 @Component({

--- a/src/components/event-modal/index.ts
+++ b/src/components/event-modal/index.ts
@@ -1,0 +1,1 @@
+export * from './event-modal';

--- a/src/components/toast/index.ts
+++ b/src/components/toast/index.ts
@@ -1,0 +1,1 @@
+export * from './toast';

--- a/src/components/toast/toast.html
+++ b/src/components/toast/toast.html
@@ -1,0 +1,7 @@
+<!-- Toast de notificação -->
+<div
+  *ngIf="showToast"
+  class="fixed bottom-4 right-4 bg-green-500 text-white px-4 py-2 rounded-md shadow-lg z-50"
+>
+  {{ message }}
+</div>

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -1,0 +1,10 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-toast',
+  templateUrl: './toast.html',
+})
+export class ToastComponent {
+  @Input() message: string = '';
+  @Input() type: 'success' | 'error' | 'warning' | 'info' = 'success';
+}


### PR DESCRIPTION
Introduces a new toast notification component with template and export, and updates the event modal interface to allow null values for its fields. Also comments out the inline event modal in the calendar component template, likely in preparation for using the new modal component.