### PR TITLE
#32 - Refactor event handling in calendar components

### DIFF
--- a/src/app/home/home.html
+++ b/src/app/home/home.html
@@ -1,9 +1,12 @@
-<app-calendar [events]="events" [eventActions]="eventActions"></app-calendar>
+<app-calendar
+  [events]="events"
+  [eventActions]="eventActions"
+  (viewEvent)="onViewEvent($event)"
+  (addEvent)="onAddEvent($event)"
+></app-calendar>
 <app-event-modal
   [show]="showEventModal"
   [modalData]="modalData"
   (close)="closeEventModal()"
   (edit)="editEvent($event)"
-  (addEvent)="onAddEvent($event)"
-  (viewEvent)="onViewEvent($event)"
 ></app-event-modal>

--- a/src/app/home/home.ts
+++ b/src/app/home/home.ts
@@ -210,7 +210,6 @@ export class HomeComponent {
   }
 
   onViewEvent(event: any): void {
-    console.log('Visualizando evento:', event);
     this.modalData = event;
     this.showEventModal = true;
   }

--- a/src/components/calendar/calendario.component.ts
+++ b/src/components/calendar/calendario.component.ts
@@ -107,8 +107,7 @@ export class CalendarioComponent {
   }
 
   onViewEvent(event: ICalendarEvent): void {
-    console.log('Visualizando evento:', event);
-    this.viewEvent.next(event);
+    this.viewEvent.emit(event);
   }
 
   onMonthChanged(monthData: { month: string; year: number }): void {


### PR DESCRIPTION
Moved viewEvent and addEvent outputs from event modal to calendar component in home.html. Replaced Subject.next with EventEmitter.emit for viewEvent in calendario.component.ts. Removed unnecessary console.log statements for cleaner event handling.